### PR TITLE
Bump Ubuntu to noble

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:jammy-20240427 AS ubuntu
+FROM ubuntu:noble-20240423 AS ubuntu
 
 # This is more likely to have up-to-date Ubuntu release info
 RUN apt update && apt install -y distro-info-data && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This is the next LTS

Have picked the second newest version, again to see if Dependabot does the bump.